### PR TITLE
Active support fix

### DIFF
--- a/lib/namecheap_api/response.rb
+++ b/lib/namecheap_api/response.rb
@@ -1,5 +1,7 @@
 require 'nokogiri'
+require 'active_support'
 require 'active_support/core_ext'
+require 'active_support/core_ext/hash/conversions'
 
 module NamecheapApi
   class Response

--- a/lib/namecheap_api/version.rb
+++ b/lib/namecheap_api/version.rb
@@ -1,3 +1,3 @@
 module NamecheapApi
-  VERSION = "0.0.1"
+  VERSION = "0.0.3"
 end

--- a/lib/namecheap_api/version.rb
+++ b/lib/namecheap_api/version.rb
@@ -1,3 +1,3 @@
 module NamecheapApi
-  VERSION = "0.0.3"
+  VERSION = "0.0.2"
 end

--- a/namecheap_api.gemspec
+++ b/namecheap_api.gemspec
@@ -7,10 +7,10 @@ Gem::Specification.new do |spec|
   spec.name          = "namecheap-api"
   spec.version       = NamecheapApi::VERSION
   spec.authors       = ["Patrick Ma", "Marc Wickenden"]
-  spec.email         = ["code@4armed.com"]
+  spec.email         = ["fivetwentysix@gmail.com"]
   spec.summary       = "a Gem for interacting with the Namecheap API"
   # spec.description   = %q{TODO: Write a longer description. Optional.}
-  spec.homepage      = "https://github.com/4ARMED/namecheap-api"
+  spec.homepage      = "https://github.com/PatrickMa/namecheap-api"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")

--- a/namecheap_api.gemspec
+++ b/namecheap_api.gemspec
@@ -6,11 +6,11 @@ require 'namecheap_api/version'
 Gem::Specification.new do |spec|
   spec.name          = "namecheap-api"
   spec.version       = NamecheapApi::VERSION
-  spec.authors       = ["Patrick Ma"]
-  spec.email         = ["fivetwentysix@gmail.com"]
+  spec.authors       = ["Patrick Ma", "Marc Wickenden"]
+  spec.email         = ["code@4armed.com"]
   spec.summary       = "a Gem for interacting with the Namecheap API"
   # spec.description   = %q{TODO: Write a longer description. Optional.}
-  spec.homepage      = "https://github.com/PatrickMa/namecheap-api"
+  spec.homepage      = "https://github.com/4ARMED/namecheap-api"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_dependency "typhoeus", "~> 0.6"
   spec.add_dependency "nokogiri", "~> 1.6"
-  spec.add_dependency "activesupport", "~> 4.1"
+  spec.add_dependency "activesupport", "~> 4.2"
 end


### PR DESCRIPTION
response.results was returning empty as result.to_h did not return a hash.

Added explicit require for 'active_support/core_ext/hash/conversions' which provides this support.