### PR TITLE
changed case statement to reflect new domains.getList response

### DIFF
--- a/lib/namecheap_api/response.rb
+++ b/lib/namecheap_api/response.rb
@@ -33,7 +33,7 @@ module NamecheapApi
 
     def result_finder
       case command
-      when 'namecheap.domains.getList'
+      when /namecheap\.domains\.get(l|L)ist/
         'DomainGetListResult > Domain'
       else
         'CommandResponse > *'


### PR DESCRIPTION
The xml response for "namecheap.domains.getList", which is the API method as documented in the API docs, says intead the request is "namecheap.domains.getlist".

As result, the response it always gives is `[nil, nil]`, when it should be a domain list. 