### PR TITLE
domains.dns.getHosts responds with the hosts list.

### DIFF
--- a/lib/namecheap_api/response.rb
+++ b/lib/namecheap_api/response.rb
@@ -35,6 +35,8 @@ module NamecheapApi
       case command
       when 'namecheap.domains.getList'
         'DomainGetListResult > Domain'
+      when /namecheap\.domains\.dns\.get(h|H)osts/
+        'DomainDNSGetHostsResult > host'
       else
         'CommandResponse > *'
       end


### PR DESCRIPTION
To access the host list, the response xml has diferent keys than the ones on the `result_finder` catch all